### PR TITLE
adds correct/incorrect css class to feedbacks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-tutor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-tutor",
   "issues": "https://adaptlearning.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10100&issuetype=1&priority=6&components=10521",

--- a/js/adapt-contrib-tutor.js
+++ b/js/adapt-contrib-tutor.js
@@ -9,6 +9,10 @@ define([
             body: view.model.get("feedbackMessage")
         };
 
+        if (view.model.has('_isCorrect')) {
+            alertObject._classes = view.model.get('_isCorrect') ? 'correct' : 'incorrect';
+        }
+
         Adapt.once("notify:closed", function() {
             Adapt.trigger("tutor:closed");
         });


### PR DESCRIPTION
Adds a class to feedback depending on the learners answer.
Can be used to add custom styles depending on correct / incorrect feedback.
Uses the _class attribute that is already present in the notify template.