### PR TITLE
Fixes #57, adds support for 'partially-correct' class

### DIFF
--- a/js/adapt-contrib-tutor.js
+++ b/js/adapt-contrib-tutor.js
@@ -10,7 +10,19 @@ define([
         };
 
         if (view.model.has('_isCorrect')) {
-            alertObject._classes = view.model.get('_isCorrect') ? 'correct' : 'incorrect';
+            // Attach specific classes so that feedback can be styled.
+            if (view.model.get('_isCorrect')) {
+                alertObject._classes = 'correct';
+            } else {
+                if (view.model.has('_isAtLeastOneCorrectSelection')) {
+                    // Partially correct feedback is an option.
+                    alertObject._classes = view.model.has('_isAtLeastOneCorrectSelection')
+                        ? 'partially-correct'
+                        : 'incorrect';
+                } else {
+                    alertObject._classes = 'incorrect';
+                }
+            }
         }
 
         Adapt.once("notify:closed", function() {
@@ -18,7 +30,7 @@ define([
         });
 
         Adapt.trigger('notify:popup', alertObject);
-        
+
         Adapt.trigger('tutor:opened');
     });
 

--- a/js/adapt-contrib-tutor.js
+++ b/js/adapt-contrib-tutor.js
@@ -16,7 +16,7 @@ define([
             } else {
                 if (view.model.has('_isAtLeastOneCorrectSelection')) {
                     // Partially correct feedback is an option.
-                    alertObject._classes = view.model.has('_isAtLeastOneCorrectSelection')
+                    alertObject._classes = view.model.get('_isAtLeastOneCorrectSelection')
                         ? 'partially-correct'
                         : 'incorrect';
                 } else {


### PR DESCRIPTION
When a question has support for a partially correct answer, a corresponding class is now added to the feedback overlay.