### PR TITLE
issue-1225: tutor events pass originating view

### DIFF
--- a/js/adapt-contrib-tutor.js
+++ b/js/adapt-contrib-tutor.js
@@ -26,12 +26,12 @@ define([
         }
 
         Adapt.once("notify:closed", function() {
-            Adapt.trigger("tutor:closed");
+            Adapt.trigger("tutor:closed", view, alertObject);
         });
 
         Adapt.trigger('notify:popup', alertObject);
 
-        Adapt.trigger('tutor:opened');
+        Adapt.trigger('tutor:opened', view, alertObject);
     });
 
 });


### PR DESCRIPTION
allow tutor:opened and tutor:closed listeners to discover source of tutor event

this is useful only for trickle at present when deciding to lock or unlock on tutor events

https://github.com/adaptlearning/adapt_framework/issues/1255