### PR TITLE
Add images to feedback

### DIFF
--- a/js/adapt-contrib-tutor.js
+++ b/js/adapt-contrib-tutor.js
@@ -12,13 +12,10 @@ define([
        * @returns {*}
        */
       function getImageSrc (image, width) {
-          var imageWidth;
-          if (width === 'medium') {
-            imageWidth = 'small'
-          } else {
-            imageWidth = width;
-          }
-          return image[imageWidth];
+        if (width !== 'large') {
+          width = 'small';
+        }
+        return image[ width ];
       }
 
       Adapt.on('questionView:showFeedback', function(view) {


### PR DESCRIPTION
Adds support for images to be displayed in feedback. Please only merge alongside other PRs on the issue.

At the moment this will display the small image on medium/small screen widths and the large image on large screen widths. If you resize the window the image will not change until the page is refreshed. I can look into this further if this is not acceptable.

Original issue: https://github.com/adaptlearning/adapt_framework/issues/1734