### PR TITLE
Fix: replace deprecated a11y_attrs_heading usage (refs #67)

### DIFF
--- a/js/TutorModel.js
+++ b/js/TutorModel.js
@@ -19,6 +19,7 @@ export default class TutorModel extends Backbone.Model {
   initialize(data, parentModel) {
     data = $.extend(true, this.defaults(), data?._isInherited === true ? null : data, {
       _attributes: { 'data-adapt-id': parentModel.get('_id') },
+      _id: parentModel.get('_id'),
       title: parentModel.get('feedbackTitle'),
       body: parentModel.get('feedbackMessage')
     });

--- a/templates/tutor.hbs
+++ b/templates/tutor.hbs
@@ -6,7 +6,7 @@
     <div class="tutor__content-inner">
 
       <div class="tutor__title">
-        <div class="tutor__title-inner" {{a11y_attrs_heading 'notify'}}>
+        <div class="tutor__title-inner" role="heading" aria-level="{{a11y_aria_level _attributes.data-adapt-id '@component+1' _ariaLevel }}">
           {{{compile title}}}
         </div>
       </div>

--- a/templates/tutor.hbs
+++ b/templates/tutor.hbs
@@ -6,7 +6,7 @@
     <div class="tutor__content-inner">
 
       <div class="tutor__title">
-        <div class="tutor__title-inner" role="heading" aria-level="{{a11y_aria_level _attributes.data-adapt-id '@component+1' _ariaLevel }}">
+        <div class="tutor__title-inner" role="heading" aria-level="{{a11y_aria_level _id '@component+1' _ariaLevel }}">
           {{{compile title}}}
         </div>
       </div>


### PR DESCRIPTION
fixes #67

### Fix
* Replace deprecated a11y_attrs_heading usage

[//]: # (Mention any other dependencies)
refs https://github.com/adaptlearning/adapt-contrib-core/issues/202

