### PR TITLE
Update: `"inline"` feedback restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As one of Adapt's _[core extensions](https://github.com/adaptlearning/adapt_fram
 
 ## Settings
 
-**\_type** (string): Question feedback display type, either `"notify"` for default pop-up, `"inline"` to appear beneath the component, `"overlay"` to cover the component or `"none"` for no feedback to be displayed.
+**\_type** (string): Question feedback display type, either `"notify"` for default pop-up, `"inline"` to appear beneath the component, `"overlay"` to cover the component or `"none"` for no feedback to be displayed. Unlike other values, `"inline"` feedback will automatically appear across sessions for submitted questions, and accordingly manipulates the core [buttonsView](https://github.com/adaptlearning/adapt-contrib-core/blob/master/js/views/buttonsView.js) by hiding `btn__feedback` and adding the `is-full-width` class to `btn__action`.
 
 **\_classes** (string): CSS class name to be applied to feedback containing div. The class must be predefined in one of the Less files. Separate multiple classes with a space.
 

--- a/js/adapt-contrib-tutor.js
+++ b/js/adapt-contrib-tutor.js
@@ -7,7 +7,33 @@ import TUTOR_TYPE from './TUTOR_TYPE';
 class Tutor extends Backbone.Controller {
 
   initialize() {
-    this.listenTo(Adapt, 'questionView:showFeedback', this.onQuestionViewShowFeedback);
+    this.listenTo(Adapt, {
+      'componentView:postRender': this.onComponentViewPostRender,
+      'questionView:showFeedback': this.onQuestionViewShowFeedback
+    });
+  }
+
+  onComponentViewPostRender(view) {
+    const model = view.model;
+    if (!model.isTypeGroup('question')) return;
+    const config = model.get('_tutor');
+    if (!config) return;
+    const type = TUTOR_TYPE(config?._type.toUpperCase());
+    if (type !== TUTOR_TYPE.INLINE) return;
+    this.listenToOnce(Adapt, 'buttonsView:postRender', this.onButtonsViewPostRender);
+    if (model.get('_canShowFeedback') && model.get('_isSubmitted')) {
+      model.setupFeedback();
+      Adapt.trigger('questionView:showFeedback', view);
+    }
+  }
+
+  onButtonsViewPostRender(view) {
+    const $btnAction = view.$('.js-btn-action');
+    const $btnFeedback = view.$('.js-btn-feedback');
+    const $btnMarking = view.$('.js-btn-marking');
+    $btnAction.addClass('is-full-width');
+    $btnFeedback.addClass('u-display-none');
+    $btnMarking.addClass('is-full-width');
   }
 
   onQuestionViewShowFeedback(view) {

--- a/js/adapt-contrib-tutor.js
+++ b/js/adapt-contrib-tutor.js
@@ -18,7 +18,7 @@ class Tutor extends Backbone.Controller {
     if (!model.isTypeGroup('question')) return;
     const config = model.get('_tutor');
     if (!config) return;
-    const type = TUTOR_TYPE(config?._type.toUpperCase());
+    const type = TUTOR_TYPE(config._type?.toUpperCase());
     if (type !== TUTOR_TYPE.INLINE) return;
     this.listenToOnce(Adapt, 'buttonsView:postRender', this.onButtonsViewPostRender);
     if (model.get('_canShowFeedback') && model.get('_isSubmitted')) {

--- a/templates/tutor.hbs
+++ b/templates/tutor.hbs
@@ -25,23 +25,14 @@
         </div>
       </div>
 
-      {{#equals _type 'inline'}}
-      <div class="tutor__btn-container">
-        <button
-          class="btn-text tutor__btn js-tutor-btn"
-          {{#if _button.ariaLabel}}aria-label="{{compile_a11y_normalize _button.ariaLabel}}"{{/if}}
-        >
-          {{{compile _button.text}}}
-        </button>
-      </div>
-      {{else}}
+      {{#any (equals _type 'notify') (equals _type 'overlay')}}
       <button
         class="btn-icon tutor__btn-icon js-tutor-btn"
         {{#if _button.ariaLabel}}aria-label="{{compile_a11y_normalize _button.ariaLabel}}"{{/if}}
       >
         <span class="icon"></span>
       </button>
-      {{/equals}}
+      {{/any}}
 
     </div>
   </div>


### PR DESCRIPTION
Fixes #80

### Update
* `"inline"` feedback is now restored automatically across sessions for submitted questions
* `btn__feedback` is hidden and `btn__action`, `btn__marking` use the `is-full-width` class when using `"inline"` feedback


