### PR TITLE
Fix: Inline feedback normalisation across course and component config (fixes #87)

### DIFF
--- a/js/adapt-contrib-tutor.js
+++ b/js/adapt-contrib-tutor.js
@@ -25,7 +25,7 @@ class Tutor extends Backbone.Controller {
 
   onButtonsViewPostRender(view) {
     const { model } = view;
-    const config = (!model.get('_tutor') || model.get('_tutor')?._isInherited === true)
+    const config = (!model.get('_tutor') || (model.get('_tutor')?._isInherited ?? true))
       ? Adapt.course.get('_tutor')
       : model.get('_tutor');
     if (!config) return;


### PR DESCRIPTION
fixes #87

### Fix
* Ensures inline feedback is displayed identically regardless of configuration origin
1. Feedback button is hidden
2. Inline feedback is always open once displayed (except when the question is reset for a subsequent attempt)