### PR TITLE
Update: add generic .notify__btn-icon class (fixes #95)

### DIFF
--- a/templates/tutor.hbs
+++ b/templates/tutor.hbs
@@ -27,7 +27,7 @@
 
       {{#any (equals _type 'notify') (equals _type 'overlay')}}
       <button
-        class="btn-icon tutor__btn-icon js-tutor-btn"
+        class="btn-icon notify__btn-icon tutor__btn-icon js-tutor-btn"
         {{#if _button.ariaLabel}}aria-label="{{compile_a11y_normalize _button.ariaLabel}}"{{/if}}
       >
         <span class="icon" aria-hidden="true"></span>


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-tutor/issues/95

Apply `.notify__btn-icon` to popup icon buttons to inherit styles from [Vanilla notify.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/142b4fde60d638e280d04d691c63fbe62bd5abfe/less/core/notify.less#LL74C3-L86C4).

Once merged, we can remove the duplicate code from [Vanilla tutor.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/142b4fde60d638e280d04d691c63fbe62bd5abfe/less/plugins/adapt-contrib-tutor/tutor.less#LL20C1-L32C4). This means the default style is set in one place but we still have plugin specific classes to target should you want to style these different - although there's good reason for keeping UI button styling consistent.