### PR TITLE
Update: use alt instead of aria-label for image alternative text (fixes #122)

### DIFF
--- a/templates/partials/tutorGraphic.hbs
+++ b/templates/partials/tutorGraphic.hbs
@@ -1,7 +1,6 @@
 {{#if showGraphic}}
 <div class="tutor__image-container{{#if _graphic.attribution}} has-attribution{{/if}}">
-  <img class="tutor__image" src="{{_graphic._src}}" 
-    {{#if _graphic.alt}}aria-label="{{{_graphic.alt}}}"{{else}}aria-hidden="true"{{/if}}>
+  <img class="tutor__image" src="{{_graphic._src}}" alt="{{{_graphic.alt}}}">
   {{#if _graphic.attribution}}
   <div class="tutor__attribution">
     <div class="tutor__attribution-inner">


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-tutor/issues/122

### Update
- replace image `aria-label` with `alt`
- remove image `aria-hidden` 

[Testing](https://github.com/adaptlearning/adapt-contrib-core/issues/822#issuecomment-3804968510) confirmed all major screen readers handle `alt` and `aria-label` equivalently and Adapt would benefit from the broader benefits of `alt`. Benefits include:
-  alternative text displayed when image fails to load 
- alternative text retained when copying images into Word or similar tools.

Testing also confirmed an empty alt tag (`alt=""`) is widely supported by screen readers / browsers to ignore an image without the need for `aria-hidden`.

### Related
- Core image template and Notify popup - https://github.com/adaptlearning/adapt-contrib-core/pull/825)
- Boxmenu header image - https://github.com/adaptlearning/adapt-contrib-boxMenu/pull/231
- Hotgraphic main image - https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/357
- LanguagePicker image - https://github.com/adaptlearning/adapt-contrib-languagePicker/pull/127
